### PR TITLE
Better HTTP Handling

### DIFF
--- a/http.ts
+++ b/http.ts
@@ -18,7 +18,7 @@ export function GraphQLHTTP<Req extends GQLRequest = GQLRequest, Ctx extends { r
   ...options
 }: GQLOptions<Ctx, Req>) {
   return async (request: Req) => {
-    const accept = request.headers.get('Accept') || '';
+    const accept = request.headers.get('Accept') || ''
     
     const typeList = [
       'text/html',
@@ -69,7 +69,7 @@ export function GraphQLHTTP<Req extends GQLRequest = GQLRequest, Ctx extends { r
       let contentType = 'text/plain'
       
       if(!typeList.length || typeList.includes('application/json') || typeList.includes('*/*'))
-        contentType = 'application/json';
+        contentType = 'application/json'
 
       return new Response(JSON.stringify(result, null, 2), {
         status: 200,

--- a/http.ts
+++ b/http.ts
@@ -1,4 +1,4 @@
-import { runHttpQuery, GQLOptions } from './common.ts'
+import { runHttpQuery, GQLOptions, GraphQLParams } from './common.ts'
 import type { GQLRequest } from './types.ts'
 
 /**
@@ -18,8 +18,31 @@ export function GraphQLHTTP<Req extends GQLRequest = GQLRequest, Ctx extends { r
   ...options
 }: GQLOptions<Ctx, Req>) {
   return async (request: Req) => {
-    if (options.graphiql && request.method === 'GET') {
-      if (request.headers.get('Accept')?.includes('text/html')) {
+    const accept = request.headers.get('Accept') || '';
+    
+    const typeList = [
+      'text/html',
+      'text/plain',
+      'application/json',
+      '*/*'
+    ].map(contentType => ({ contentType, index: accept.indexOf(contentType) }))
+      .filter(({ index }) => index >= 0)
+      .sort((a, b) => a.index - b.index)
+      .map(({ contentType }) => contentType)
+
+    if (accept && !typeList.length) {
+      return new Response('Not Acceptable', { status: 406, headers: new Headers(headers) })
+    } else if (!['GET', 'PUT', 'POST', 'PATCH'].includes(request.method)) {
+      return new Response('Method Not Allowed', { status: 405, headers: new Headers(headers) })
+    }
+
+    let params: Promise<GraphQLParams>
+    
+    if (request.method === 'GET') {
+      const urlQuery = request.url.substring(request.url.indexOf('?'))
+      const queryParams = new URLSearchParams(urlQuery)
+
+      if (options.graphiql && typeList[0] === 'text/html' && !queryParams.has('raw')) {
         const { renderPlaygroundPage } = await import('./graphiql/render.ts')
         const playground = renderPlaygroundPage({ ...playgroundOptions, endpoint: '/graphql' })
 
@@ -29,35 +52,38 @@ export function GraphQLHTTP<Req extends GQLRequest = GQLRequest, Ctx extends { r
             ...headers
           })
         })
+      } else if (queryParams.has('query')) {
+        params = Promise.resolve({ query: queryParams.get('query') } as GraphQLParams)
       } else {
-        return new Response('"Accept" header value must include text/html', {
-          status: 400,
-
-          headers: new Headers(headers)
-        })
+        params = Promise.reject(new Error('No query given!'))
       }
+    } else if (typeList.length === 1 && typeList[0] === 'text/html') {
+      return new Response('Not Acceptable', { status: 406, headers: new Headers(headers) })
     } else {
-      if (!['PUT', 'POST', 'PATCH'].includes(request.method)) {
-        return new Response('Method Not Allowed', { status: 405, headers: new Headers(headers) })
-      } else {
-        try {
-          const result = await runHttpQuery<Req, Ctx>(await request.json(), options, { request })
+      params = request.json()
+    }
 
-          return new Response(JSON.stringify(result, null, 2), {
-            status: 200,
-            headers: new Headers({
-              'Content-Type': 'application/json',
-              ...headers
-            })
-          })
-        } catch (e) {
-          console.error(e)
-          return new Response('Malformed request body', {
-            status: 400,
-            headers: new Headers(headers)
-          })
-        }
-      }
+    try {
+      const result = await runHttpQuery<Req, Ctx>(await params, options, { request })
+
+      let contentType = 'text/plain'
+      
+      if(!typeList.length || typeList.includes('application/json') || typeList.includes('*/*'))
+        contentType = 'application/json';
+
+      return new Response(JSON.stringify(result, null, 2), {
+        status: 200,
+        headers: new Headers({
+          'Content-Type': contentType,
+          ...headers
+        })
+      })
+    } catch (e) {
+      console.error(e)
+      return new Response('Malformed Request ' + (request.method === 'GET' ? 'Query' : 'Body'), {
+        status: 400,
+        headers: new Headers(headers)
+      })
     }
   }
 }

--- a/http.ts
+++ b/http.ts
@@ -52,6 +52,8 @@ export function GraphQLHTTP<Req extends GQLRequest = GQLRequest, Ctx extends { r
             ...headers
           })
         })
+      } else if(typeList.length === 1 && typeList[0] === 'text/html') {
+        return new Response('Not Acceptable', { status: 406, headers: new Headers(headers) })
       } else if (queryParams.has('query')) {
         params = Promise.resolve({ query: queryParams.get('query') } as GraphQLParams)
       } else {


### PR DESCRIPTION
This PR changes the `http` module to:
- handle different accept/content types
- handle graphql GET ?query requests

I tried to stay within the same code style but let me know/feel free to make changes.

Also: `contentType` defaults to `text/plain` because there is more logic to check if it is supposed to be that then if it is supposed to be `application/json` so it was simpler to do it this way (as far as I am aware).

This would close #6 .