### PR TITLE
Fix Vanilla (STD) Example

### DIFF
--- a/examples/vanilla.ts
+++ b/examples/vanilla.ts
@@ -28,7 +28,9 @@ const s = new Server({
         })(req)
       : new Response('Not Found', { status: 404 })
   },
-  addr: ':3000'
+  port: 3000
 })
 
 s.listenAndServe()
+
+console.log(`☁  Started on http://localhost:3000`)


### PR DESCRIPTION
`addr` needed to be switched to `port`, and I added the `console.log` as well.